### PR TITLE
Move `frameworkType` in `initializeSDK`

### DIFF
--- a/help/mobile/react-native.md
+++ b/help/mobile/react-native.md
@@ -133,7 +133,7 @@ public class RNMarketoModule extends ReactContextBaseJavaModule {
    }
    @ReactMethod
       public void initializeSDK(String frameworkType, String munchkinId, String appSecreteKey){
-          marketoSdk.initializeSDK(munchkinId,appSecreteKey,frameworkType);
+          marketoSdk.initializeSDK(frameworkType,munchkinId,appSecreteKey);
     }
    
 


### PR DESCRIPTION
`frameworkType` is first parameter in `initializeSDK` function
Appears as such from IntelliSense suggestions

<img width="1081" alt="Screenshot 2025-05-05 at 5 12 13 pm" src="https://github.com/user-attachments/assets/08e9c7f8-d1c8-4f10-8402-1d6113b64492" />
 